### PR TITLE
Maint/testing faster travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 sudo: required
 dist: trusty
 language: generic
+services:
+  - docker
 compiler:
   - gcc
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,18 +10,18 @@ notifications:
 
 env:
   matrix:
-    - ROS_DISTRO="indigo" ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu UPSTREAM_WORKSPACE=file DOCKER_BASE_IMAGE=ros:indigo-robot
-    - ROS_DISTRO="indigo" ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu UPSTREAM_WORKSPACE=file DOCKER_BASE_IMAGE=ros:indigo-robot
-    - ROS_DISTRO="kinetic" ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu UPSTREAM_WORKSPACE=file DOCKER_BASE_IMAGE=ros:kinetic-robot
-    - ROS_DISTRO="kinetic" ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu UPSTREAM_WORKSPACE=file DOCKER_BASE_IMAGE=ros:kinetic-robot
-    - ROS_DISTRO="lunar" ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu UPSTREAM_WORKSPACE=file DOCKER_BASE_IMAGE=ros:lunar-robot
-    - ROS_DISTRO="lunar" ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu UPSTREAM_WORKSPACE=file DOCKER_BASE_IMAGE=ros:lunar-robot
+    - ROS_DISTRO="indigo" ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu UPSTREAM_WORKSPACE=file DOCKER_BASE_IMAGE=ros:indigo-core
+    - ROS_DISTRO="indigo" ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu UPSTREAM_WORKSPACE=file DOCKER_BASE_IMAGE=ros:indigo-core
+    - ROS_DISTRO="kinetic" ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu UPSTREAM_WORKSPACE=file DOCKER_BASE_IMAGE=ros:kinetic-core
+    - ROS_DISTRO="kinetic" ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu UPSTREAM_WORKSPACE=file DOCKER_BASE_IMAGE=ros:kinetic-core
+    - ROS_DISTRO="lunar" ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu UPSTREAM_WORKSPACE=file DOCKER_BASE_IMAGE=ros:lunar-core
+    - ROS_DISTRO="lunar" ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu UPSTREAM_WORKSPACE=file DOCKER_BASE_IMAGE=ros:lunar-core
 
 matrix:
   allow_failures:
-    env: ROS_DISTRO="indigo" ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu UPSTREAM_WORKSPACE=file DOCKER_BASE_IMAGE=ros:indigo-robot
-    env: ROS_DISTRO="kinetic" ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu UPSTREAM_WORKSPACE=file DOCKER_BASE_IMAGE=ros:kinetic-robot
-    env: ROS_DISTRO="lunar" ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu UPSTREAM_WORKSPACE=file DOCKER_BASE_IMAGE=ros:lunar-robot
+    env: ROS_DISTRO="indigo" ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu UPSTREAM_WORKSPACE=file DOCKER_BASE_IMAGE=ros:indigo-core
+    env: ROS_DISTRO="kinetic" ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu UPSTREAM_WORKSPACE=file DOCKER_BASE_IMAGE=ros:kinetic-core
+    env: ROS_DISTRO="lunar" ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu UPSTREAM_WORKSPACE=file DOCKER_BASE_IMAGE=ros:lunar-core
 
 install:
   git clone https://github.com/ros-industrial/industrial_ci.git .ci_config

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,18 +10,18 @@ notifications:
 
 env:
   matrix:
-    - ROS_DISTRO="indigo" ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu UPSTREAM_WORKSPACE=file
-    - ROS_DISTRO="indigo" ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu UPSTREAM_WORKSPACE=file
-    - ROS_DISTRO="kinetic" ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu UPSTREAM_WORKSPACE=file
-    - ROS_DISTRO="kinetic" ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu UPSTREAM_WORKSPACE=file
-    - ROS_DISTRO="lunar" ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu UPSTREAM_WORKSPACE=file
-    - ROS_DISTRO="lunar" ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu UPSTREAM_WORKSPACE=file
+    - ROS_DISTRO="indigo" ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu UPSTREAM_WORKSPACE=file DOCKER_BASE_IMAGE=ros:indigo-robot
+    - ROS_DISTRO="indigo" ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu UPSTREAM_WORKSPACE=file DOCKER_BASE_IMAGE=ros:indigo-robot
+    - ROS_DISTRO="kinetic" ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu UPSTREAM_WORKSPACE=file DOCKER_BASE_IMAGE=ros:kinetic-robot
+    - ROS_DISTRO="kinetic" ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu UPSTREAM_WORKSPACE=file DOCKER_BASE_IMAGE=ros:kinetic-robot
+    - ROS_DISTRO="lunar" ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu UPSTREAM_WORKSPACE=file DOCKER_BASE_IMAGE=ros:lunar-robot
+    - ROS_DISTRO="lunar" ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu UPSTREAM_WORKSPACE=file DOCKER_BASE_IMAGE=ros:lunar-robot
 
 matrix:
   allow_failures:
-    env: ROS_DISTRO="indigo" ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu UPSTREAM_WORKSPACE=file
-    env: ROS_DISTRO="kinetic" ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu UPSTREAM_WORKSPACE=file
-    env: ROS_DISTRO="lunar" ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu UPSTREAM_WORKSPACE=file
+    env: ROS_DISTRO="indigo" ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu UPSTREAM_WORKSPACE=file DOCKER_BASE_IMAGE=ros:indigo-robot
+    env: ROS_DISTRO="kinetic" ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu UPSTREAM_WORKSPACE=file DOCKER_BASE_IMAGE=ros:kinetic-robot
+    env: ROS_DISTRO="lunar" ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu UPSTREAM_WORKSPACE=file DOCKER_BASE_IMAGE=ros:lunar-robot
 
 install:
   git clone https://github.com/ros-industrial/industrial_ci.git .ci_config

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,18 +10,18 @@ notifications:
 
 env:
   matrix:
-    - ROS_DISTRO="indigo" ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu UPSTREAM_WORKSPACE=file DOCKER_BASE_IMAGE=ros:indigo-core
-    - ROS_DISTRO="indigo" ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu UPSTREAM_WORKSPACE=file DOCKER_BASE_IMAGE=ros:indigo-core
-    - ROS_DISTRO="kinetic" ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu UPSTREAM_WORKSPACE=file DOCKER_BASE_IMAGE=ros:kinetic-core
-    - ROS_DISTRO="kinetic" ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu UPSTREAM_WORKSPACE=file DOCKER_BASE_IMAGE=ros:kinetic-core
-    - ROS_DISTRO="lunar" ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu UPSTREAM_WORKSPACE=file DOCKER_BASE_IMAGE=ros:lunar-core
-    - ROS_DISTRO="lunar" ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu UPSTREAM_WORKSPACE=file DOCKER_BASE_IMAGE=ros:lunar-core
+    - ROS_DISTRO="indigo" ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu UPSTREAM_WORKSPACE=file DOCKER_BASE_IMAGE=ros:indigo-ros-core
+    - ROS_DISTRO="indigo" ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu UPSTREAM_WORKSPACE=file DOCKER_BASE_IMAGE=ros:indigo-ros-core
+    - ROS_DISTRO="kinetic" ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu UPSTREAM_WORKSPACE=file DOCKER_BASE_IMAGE=ros:kinetic-ros-core
+    - ROS_DISTRO="kinetic" ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu UPSTREAM_WORKSPACE=file DOCKER_BASE_IMAGE=ros:kinetic-ros-core
+    - ROS_DISTRO="lunar" ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu UPSTREAM_WORKSPACE=file DOCKER_BASE_IMAGE=ros:lunar-ros-core
+    - ROS_DISTRO="lunar" ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu UPSTREAM_WORKSPACE=file DOCKER_BASE_IMAGE=ros:lunar-ros-core
 
 matrix:
   allow_failures:
-    env: ROS_DISTRO="indigo" ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu UPSTREAM_WORKSPACE=file DOCKER_BASE_IMAGE=ros:indigo-core
-    env: ROS_DISTRO="kinetic" ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu UPSTREAM_WORKSPACE=file DOCKER_BASE_IMAGE=ros:kinetic-core
-    env: ROS_DISTRO="lunar" ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu UPSTREAM_WORKSPACE=file DOCKER_BASE_IMAGE=ros:lunar-core
+    env: ROS_DISTRO="indigo" ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu UPSTREAM_WORKSPACE=file DOCKER_BASE_IMAGE=ros:indigo-ros-core
+    env: ROS_DISTRO="kinetic" ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu UPSTREAM_WORKSPACE=file DOCKER_BASE_IMAGE=ros:kinetic-ros-core
+    env: ROS_DISTRO="lunar" ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu UPSTREAM_WORKSPACE=file DOCKER_BASE_IMAGE=ros:lunar-ros-core
 
 install:
   git clone https://github.com/ros-industrial/industrial_ci.git .ci_config

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # PACMod (Platform Actuation and Control MODule) Vehicle Interface #
 
-[![Build Status](https://travis-ci.org/astuff/ros_pacmod.svg?branch=master)](https://travis-ci.org/astuff/ros_pacmod)
+[![Build Status](https://travis-ci.org/astuff/pacmod.svg?branch=master)](https://travis-ci.org/astuff/pacmod)
 
 This ROS node is designed to allow the user to control a vehicle (see SUPPORTED VEHICLES below) with the PACMod drive-by-wire system. For more information about the topics, parameters, and details on the implementation, see [the wiki page](https://autonomoustuff.atlassian.net/wiki/spaces/RW/pages/17749288/PACMod+System).
 


### PR DESCRIPTION
Uses a ROS-based docker image instead of the default vanilla Ubuntu images. This speeds up the build by almost 4 minutes across the 6 tested environments.