### PR TITLE
URGENT: Fix message changes from pacmod_msgs.

### DIFF
--- a/include/pacmod/pacmod_core.h
+++ b/include/pacmod/pacmod_core.h
@@ -324,9 +324,9 @@ public:
   static const int64_t CAN_ID;
 
   double dt;
-  double Kp;
-  double Ki;
-  double Kd;
+  double kp;
+  double ki;
+  double kd;
 
   void parse(uint8_t *in);
 };
@@ -337,9 +337,9 @@ class SteeringPIDRpt2Msg :
 public:
   static const int64_t CAN_ID;
 
-  double P_term;
-  double I_term;
-  double D_term;
+  double p_term;
+  double i_term;
+  double d_term;
   double all_terms;
 
   void parse(uint8_t *in);

--- a/src/pacmod_core.cpp
+++ b/src/pacmod_core.cpp
@@ -398,13 +398,13 @@ void SteeringPIDRpt1Msg::parse(uint8_t *in)
   dt = static_cast<double>(temp / 1000.0);
 
   temp = (static_cast<int16_t>(in[2]) << 8) | in[3];
-  Kp = static_cast<double>(temp / 1000.0);
+  kp = static_cast<double>(temp / 1000.0);
 
   temp = (static_cast<int16_t>(in[4]) << 8) | in[5];
-  Ki = static_cast<double>(temp / 1000.0);
+  ki = static_cast<double>(temp / 1000.0);
 
   temp = (static_cast<int16_t>(in[6]) << 8) | in[7];
-  Kd = static_cast<double>(temp / 1000.0);
+  kd = static_cast<double>(temp / 1000.0);
 }
 
 void SteeringPIDRpt2Msg::parse(uint8_t *in)
@@ -412,13 +412,13 @@ void SteeringPIDRpt2Msg::parse(uint8_t *in)
   int16_t temp;
 
   temp = (static_cast<int16_t>(in[0]) << 8) | in[1];
-  P_term = static_cast<double>(temp / 1000.0);
+  p_term = static_cast<double>(temp / 1000.0);
 
   temp = (static_cast<int16_t>(in[2]) << 8) | in[3];
-  I_term = static_cast<double>(temp / 1000.0);
+  i_term = static_cast<double>(temp / 1000.0);
 
   temp = (static_cast<int16_t>(in[4]) << 8) | in[5];
-  D_term = static_cast<double>(temp / 1000.0);
+  d_term = static_cast<double>(temp / 1000.0);
 
   temp = (static_cast<int16_t>(in[6]) << 8) | in[7];
   all_terms = static_cast<double>(temp / 1000.0);

--- a/src/pacmod_ros_msg_handler.cpp
+++ b/src/pacmod_ros_msg_handler.cpp
@@ -305,9 +305,9 @@ void PacmodTxRosMsgHandler::fillSteeringPIDRpt1(const std::shared_ptr<PacmodTxMs
   auto dc_parser = std::dynamic_pointer_cast<SteeringPIDRpt1Msg>(parser_class);
 
   new_msg->dt = dc_parser->dt;
-  new_msg->Kp = dc_parser->Kp;
-  new_msg->Ki = dc_parser->Ki;
-  new_msg->Kd = dc_parser->Kd;
+  new_msg->kp = dc_parser->kp;
+  new_msg->ki = dc_parser->ki;
+  new_msg->kd = dc_parser->kd;
 
   new_msg->header.frame_id = frame_id;
   new_msg->header.stamp = ros::Time::now();
@@ -319,9 +319,9 @@ void PacmodTxRosMsgHandler::fillSteeringPIDRpt2(const std::shared_ptr<PacmodTxMs
 {
   auto dc_parser = std::dynamic_pointer_cast<SteeringPIDRpt2Msg>(parser_class);
 
-  new_msg->P_term = dc_parser->P_term;
-  new_msg->I_term = dc_parser->I_term;
-  new_msg->D_term = dc_parser->D_term;
+  new_msg->p_term = dc_parser->p_term;
+  new_msg->i_term = dc_parser->i_term;
+  new_msg->d_term = dc_parser->d_term;
   new_msg->all_terms = dc_parser->all_terms;
 
   new_msg->header.frame_id = frame_id;


### PR DESCRIPTION
This updates the driver to match changes to `pacmod_msgs` which have already been released. This will get released to Kinetic only. CI will fail on Kinetic because the new `pacmod_msgs` has not been sync'd to the repo yet.